### PR TITLE
serial: `CONFIG_USB_CDC_ACM` adds file to library

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_XLNX_PS uart_xlnx_ps.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XLNX_UARTLITE uart_xlnx_uartlite.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XMC4XXX uart_xmc4xxx.c)
 zephyr_library_sources_ifdef(CONFIG_UART_NPCX uart_npcx.c)
+zephyr_library_sources_ifdef(CONFIG_USB_CDC_ACM ${ZEPHYR_BASE}/misc/empty_file.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 


### PR DESCRIPTION
This is a cherry pick of zephyrproject-rtos/zephyr#31068 for our fork. The key addition here is we can stop requiring boards to enable `uart0` and set unused pins on that device just to turn on USB logging. Most of our in tree boards are required to do this currently, just for USB logging, not because we actually want to set up the UART device by default. By merging this, we can *remove* that from these boards, and clean up that stupid hack.

Original commit description:


It is possible to use the UART abstraction for USB communications
without any of the dedicated UART drivers being enabled. This currently
causes a compilation error because CMake throws an error if a library
has no sources. The empty file forces there to be at least one file in
the library when `CONFIG_USB_CDC_ACM` is enabled.

Removing `select CONFIG_SERIAL_HAS_DRIVER` from `CONFIG_USB_CDC_ACM` is
not a valid solution as this symbol is required by `CONFIG_UART_CONSOLE`
and therefore `USB_UART_CONSOLE`.

Fixes #31067.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>
(cherry picked from commit 8e2b2fe595d8e8ec7408ccfed3ce296e0dba8404)