### PR TITLE
Bluetooth: GATT: Fix BT_GATT_AUTO_DISCOVER_CCC

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4096,10 +4096,7 @@ int bt_gatt_subscribe(struct bt_conn *conn,
 
 #if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC)
 		if (!params->ccc_handle) {
-			err = gatt_ccc_discover(conn, params);
-			if (err) {
-				return err;
-			}
+			return gatt_ccc_discover(conn, params);
 		}
 #endif
 		err = gatt_write_ccc(conn, params->ccc_handle, params->value,


### PR DESCRIPTION
Backport of a Zephyr `master` fix for auto discover of GATT CCC descriptors when subscribing for notifications/indications. I'm using this for the cleaned up code in zmkfirmware/zmk#547 that @joelspadin noted. By adding this, we can avoid doing a bunch of extra discovery tracking ourselves, and let Zephyr stack handle it. 

When using BT_GATT_AUTO_DISCOVER_CCC if the ccc_handle is not set
bt_gatt_subscribe would initiate a discovery to locate the CCC handle
but instead of awaiting it to complete the code does proceed to call
gatt_write_ccc even with ccc_handle being 0x0000 which is invalid.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
(cherry picked from commit 64cc5a37465a3cd2c227746edf614a0174b25060)