### PR TITLE
Improve LED drivers

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_HT16K33 ht16k33.c)
+zephyr_sources_ifdef(CONFIG_LED_GPIO led_gpio.c)
 zephyr_sources_ifdef(CONFIG_LED_PWM led_pwm.c)
 zephyr_sources_ifdef(CONFIG_LP3943 lp3943.c)
 zephyr_sources_ifdef(CONFIG_LP503X lp503x.c)

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,6 +26,7 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+source "drivers/led/Kconfig.gpio"
 source "drivers/led/Kconfig.ht16k33"
 source "drivers/led/Kconfig.lp3943"
 source "drivers/led/Kconfig.lp503x"

--- a/drivers/led/Kconfig.gpio
+++ b/drivers/led/Kconfig.gpio
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config LED_GPIO
+	bool "GPIO LED driver"
+	depends on GPIO && $(dt_compat_enabled,gpio-leds)
+	help
+	  Enable driver for GPIO LEDs.

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gpio_leds
+
+/**
+ * @file
+ * @brief GPIO driven LEDs
+ */
+
+#include <drivers/led.h>
+#include <drivers/gpio.h>
+#include <device.h>
+#include <zephyr.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(led_gpio, CONFIG_LED_LOG_LEVEL);
+
+struct gpio_dt_spec {
+	const struct device *port;
+	gpio_pin_t pin;
+	gpio_dt_flags_t dt_flags;
+};
+
+struct led_gpio_config {
+	size_t num_leds;
+	const struct gpio_dt_spec *led;
+};
+
+static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
+{
+
+	const struct led_gpio_config *config = dev->config;
+	const struct gpio_dt_spec *led_gpio;
+
+	if ((led >= config->num_leds) || (value > 100)) {
+		return -EINVAL;
+	}
+
+	led_gpio = &config->led[led];
+
+	return gpio_pin_set(led_gpio->port, led_gpio->pin, value > 0);
+}
+
+static int led_gpio_on(const struct device *dev, uint32_t led)
+{
+	return led_gpio_set_brightness(dev, led, 100);
+}
+
+static int led_gpio_off(const struct device *dev, uint32_t led)
+{
+	return led_gpio_set_brightness(dev, led, 0);
+}
+
+static int led_gpio_init(const struct device *dev)
+{
+	const struct led_gpio_config *config = dev->config;
+	int err = 0;
+
+	if (!config->num_leds) {
+		LOG_ERR("%s: no LEDs found (DT child nodes missing)", dev->name);
+		err = -ENODEV;
+	}
+
+	for (size_t i = 0; (i < config->num_leds) && !err; i++) {
+		const struct gpio_dt_spec *led = &config->led[i];
+
+		if (device_is_ready(led->port)) {
+			err = gpio_pin_configure(led->port, led->pin, led->dt_flags | GPIO_OUTPUT_INACTIVE);
+
+			if (err) {
+				LOG_ERR("Cannot configure GPIO (err %d)", err);
+			}
+		} else {
+			LOG_ERR("%s: GPIO device not ready", dev->name);
+			err = -ENODEV;
+		}
+	}
+
+	return err;
+}
+
+static const struct led_driver_api led_gpio_api = {
+	.on		= led_gpio_on,
+	.off		= led_gpio_off,
+	.set_brightness	= led_gpio_set_brightness,
+};
+
+#define LED_GPIO_DT_SPEC(led_node_id)								\
+{											\
+	.port		= DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(led_node_id, gpios, 0)),	\
+	.pin		= DT_GPIO_PIN_BY_IDX(led_node_id, gpios, 0),			\
+	.dt_flags	= DT_GPIO_FLAGS_BY_IDX(led_node_id, gpios, 0),			\
+},
+
+#define LED_GPIO_DEVICE(i)					\
+								\
+static const struct gpio_dt_spec gpio_dt_spec_##i[] = {		\
+	DT_INST_FOREACH_CHILD(i, LED_GPIO_DT_SPEC)		\
+};								\
+								\
+static const struct led_gpio_config led_gpio_config_##i = {	\
+	.num_leds	= ARRAY_SIZE(gpio_dt_spec_##i),		\
+	.led		= gpio_dt_spec_##i,			\
+};								\
+								\
+DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
+		      NULL, &led_gpio_config_##i,		\
+		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
+		      &led_gpio_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LED_GPIO_DEVICE)

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -153,8 +153,7 @@ const struct led_pwm_config led_pwm_config_##id = {		\
 static struct led_pwm_data					\
 	led_pwm_data_##id[ARRAY_SIZE(led_pwm_##id)];		\
 								\
-DEVICE_DEFINE(led_pwm_##id,					\
-		    DT_INST_PROP_OR(id, label, "LED_PWM_"#id),	\
+DEVICE_DT_INST_DEFINE(id,					\
 		    &led_pwm_init,				\
 		    device_pm_control_nop,			\
 		    &led_pwm_data_##id,				\


### PR DESCRIPTION
- Backport LED GPIO driver which was added in Zephyr 2.6
- Fix LED PWM driver which did not initialize devices correctly