### PR TITLE
boards: Seeeduino XIAO BLE charge current select.

### DIFF
--- a/boards/arm/seeeduino_xiao_ble/CMakeLists.txt
+++ b/boards/arm/seeeduino_xiao_ble/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(CONFIG_BOARD_CHARGE_RATE_100MA)
+zephyr_library()
+zephyr_library_sources(board.c)
+endif()

--- a/boards/arm/seeeduino_xiao_ble/Kconfig
+++ b/boards/arm/seeeduino_xiao_ble/Kconfig
@@ -8,3 +8,15 @@ config BOARD_ENABLE_DCDC
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_SEEEDUINO_XIAO_BLE
+
+choice BOARD_CHARGE_RATE
+	prompt "LiPo Charge Rate"
+	depends on BOARD_SEEEDUINO_XIAO_BLE
+
+config BOARD_CHARGE_RATE_50MA
+	bool "50mA"
+
+config BOARD_CHARGE_RATE_100MA
+	bool "100mA"
+
+endchoice

--- a/boards/arm/seeeduino_xiao_ble/board.c
+++ b/boards/arm/seeeduino_xiao_ble/board.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+#include <hal/nrf_gpio.h>
+#include <nrfx.h>
+#include <device.h>
+#include <drivers/gpio.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(seeeduino_xiao_ble_board_init);
+
+#define XIAO_BLE_CHARGE_CTRL_PORT DT_LABEL(DT_NODELABEL(gpio0))
+#define XIAO_BLE_CHARGE_CTRL_PIN 13
+
+static int setup(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	const struct device *gpio;
+	int err;
+
+	gpio = device_get_binding(XIAO_BLE_CHARGE_CTRL_PORT);
+        if (!gpio) {
+                LOG_ERR("Could not bind device \"%s\"", XIAO_BLE_CHARGE_CTRL_PORT);
+                return -ENODEV;
+        }
+
+	err = gpio_pin_configure(gpio, XIAO_BLE_CHARGE_CTRL_PIN, GPIO_OUTPUT_LOW);
+
+	if (err < 0) {
+                LOG_ERR("Failed to set charge pin low for high charge rate");
+                return err;
+	}
+
+	return 0;
+}
+
+SYS_INIT(setup, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Add board Kconfig option to allow selecting a fixed charge current, either 50mA or 100mA, at startup.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>