### PR TITLE
changed order of loops from foreach dir -> foreach shield to foreach

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -300,33 +300,34 @@ endif()
 # After processing all shields, only invalid shields will be left in this list.
 set(SHIELD-NOTFOUND ${SHIELD_AS_LIST})
 
-# Use BOARD to search for a '_defconfig' file.
-# e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig.
-# When found, use that path to infer the ARCH we are building for.
-foreach(root ${BOARD_ROOT})
-  set(shield_dir ${root}/boards/shields)
-  # Match the Kconfig.shield files in the shield directories to make sure we are
-  # finding shields, e.g. x_nucleo_iks01a1/Kconfig.shield
-  file(GLOB_RECURSE shields_refs_list ${shield_dir}/*/Kconfig.shield)
 
-  # The above gives a list like
-  # x_nucleo_iks01a1/Kconfig.shield;x_nucleo_iks01a2/Kconfig.shield
-  # we construct a list of shield names by extracting the folder and find
-  # and overlay files in there. Each overlay corresponds to a shield.
-  # We obtain the shield name by removing the overlay extension.
-  unset(SHIELD_LIST)
-  foreach(shields_refs ${shields_refs_list})
-    get_filename_component(shield_path ${shields_refs} DIRECTORY)
-    file(GLOB shield_overlays RELATIVE ${shield_path} ${shield_path}/*.overlay)
-    foreach(overlay ${shield_overlays})
-      get_filename_component(shield ${overlay} NAME_WE)
-      list(APPEND SHIELD_LIST ${shield})
-      set(SHIELD_DIR_${shield} ${shield_path})
-    endforeach()
-  endforeach()
+if(DEFINED SHIELD)
+  foreach(s ${SHIELD_AS_LIST})
+    # Use BOARD to search for a '_defconfig' file.
+    # e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig.
+    # When found, use that path to infer the ARCH we are building for.
+    foreach(root ${BOARD_ROOT})
+      set(shield_dir ${root}/boards/shields)
+      # Match the Kconfig.shield files in the shield directories to make sure we are
+      # finding shields, e.g. x_nucleo_iks01a1/Kconfig.shield
+      file(GLOB_RECURSE shields_refs_list ${shield_dir}/*/Kconfig.shield)
 
-  if(DEFINED SHIELD)
-    foreach(s ${SHIELD_AS_LIST})
+      # The above gives a list like
+      # x_nucleo_iks01a1/Kconfig.shield;x_nucleo_iks01a2/Kconfig.shield
+      # we construct a list of shield names by extracting the folder and find
+      # and overlay files in there. Each overlay corresponds to a shield.
+      # We obtain the shield name by removing the overlay extension.
+      unset(SHIELD_LIST)
+      foreach(shields_refs ${shields_refs_list})
+        get_filename_component(shield_path ${shields_refs} DIRECTORY)
+        file(GLOB shield_overlays RELATIVE ${shield_path} ${shield_path}/*.overlay)
+        foreach(overlay ${shield_overlays})
+          get_filename_component(shield ${overlay} NAME_WE)
+          list(APPEND SHIELD_LIST ${shield})
+          set(SHIELD_DIR_${shield} ${shield_path})
+        endforeach()
+      endforeach()
+      message("looking for ${s} in ${root}")
       if(NOT ${s} IN_LIST SHIELD_LIST)
         continue()
       endif()
@@ -360,16 +361,16 @@ foreach(root ${BOARD_ROOT})
       endif()
 
       zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards
-                  DTS   shield_dts_files
-                  KCONF shield_conf_files
-      )
+        DTS   shield_dts_files
+        KCONF shield_conf_files
+        )
       zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards/${s}
-                  DTS   shield_dts_files
-                  KCONF shield_conf_files
-      )
+        DTS   shield_dts_files
+        KCONF shield_conf_files
+        )
     endforeach()
-  endif()
-endforeach()
+  endforeach()
+endif()
 
 if(NOT BOARD_DIR)
   message("No board named '${BOARD}' found.


### PR DESCRIPTION
Invert the logic so that each set of possible locations is checked for each shield - otherwise, if multiple shields are passed to build, instead of respecting the sequence of shields as provided, they will be grouped by location first, then by shield