### PR TITLE
Update STM32 HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ab42f7015e16500db4a51ba562eee36460b7473e
+      revision: f1cae48438a1ababa5e27b261f9e2d172afe6cf7
       path: modules/hal/stm32
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 300109f80730cb2477bfcc706a6602b9870336b3
+      revision: ab42f7015e16500db4a51ba562eee36460b7473e
       path: modules/hal/stm32
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: f1cae48438a1ababa5e27b261f9e2d172afe6cf7
+      revision: 13964e0af173f19fafad3692869e8486f3c2043d
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Some updates in upstream STM32Cube are required to get Keychron Q1 (STM32L4) works. This PR cherry-picked some commits from zephyr v3.1-branch.