### PR TITLE
Cherry picks - qdec nrfx trigger pointer fix

### DIFF
--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -139,7 +139,7 @@ static int qdec_nrfx_trigger_set(const struct device *dev,
 static void qdec_nrfx_event_handler(nrfx_qdec_event_t event)
 {
 	sensor_trigger_handler_t handler;
-	const struct sensor_trigger *trig,
+	const struct sensor_trigger *trig;
 	unsigned int key;
 
 	switch (event.type) {

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(qdec_nrfx, CONFIG_SENSOR_LOG_LEVEL);
 struct qdec_nrfx_data {
 	int32_t                    acc;
 	sensor_trigger_handler_t data_ready_handler;
+	const struct sensor_trigger *data_ready_trigger;
 };
 
 static struct qdec_nrfx_data qdec_nrfx_data;
@@ -129,6 +130,7 @@ static int qdec_nrfx_trigger_set(const struct device *dev,
 
 	key = irq_lock();
 	data->data_ready_handler = handler;
+	data->data_ready_trigger = trig;
 	irq_unlock(key);
 
 	return 0;
@@ -137,6 +139,7 @@ static int qdec_nrfx_trigger_set(const struct device *dev,
 static void qdec_nrfx_event_handler(nrfx_qdec_event_t event)
 {
 	sensor_trigger_handler_t handler;
+	const struct sensor_trigger *trig,
 	unsigned int key;
 
 	switch (event.type) {
@@ -145,15 +148,11 @@ static void qdec_nrfx_event_handler(nrfx_qdec_event_t event)
 
 		key = irq_lock();
 		handler = qdec_nrfx_data.data_ready_handler;
+		trig = qdec_nrfx_data.data_ready_trigger;
 		irq_unlock(key);
 
 		if (handler) {
-			struct sensor_trigger trig = {
-				.type = SENSOR_TRIG_DATA_READY,
-				.chan = SENSOR_CHAN_ROTATION,
-			};
-
-			handler(DEVICE_DT_INST_GET(0), &trig);
+			handler(DEVICE_DT_INST_GET(0), trig);
 		}
 		break;
 


### PR DESCRIPTION
Pull in this fix from Zephyr `main` to make the trigger pointer be as expected for qdec_nrfx driver. See https://github.com/zephyrproject-rtos/zephyr/commit/6836d03dc097b3bcb0ea3d9171a7224e09ffec1b