### PR TITLE
Bluetooth: Controller: legacy: Fix conn upd instant passed on data tx

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -436,20 +436,40 @@ config BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING
 	depends on BT_CTLR_SCHED_ADVANCED
 	default 0
 	help
-	  The central preferred connection spacing defines an additional spacing
-	  in microseconds, added to the fixed ~1250 us spacing obtained by enabling
-	  BT_CTLR_SCHED_ADVANCED. Specifying 0 (default) will obtain a spacing of
-	  ~1250 us, whereas specifying 1250 will yield a spacing of ~2500 us.
-	  The spacing is defined as the distance in time between the anchor points
-	  of the established central role connections.
-	  The precision is determined by the resolution of the platform dependent
-	  ticker clock.
-	  When specifying values above 6.25 ms, the spacing may be unobtainable if
-	  the connection interval becomes smaller than the total spacing. In that
-	  case, modulo is applied and a total spacing of 15 ms on a 10 ms connection
-	  interval yields 5 ms spacing.
-	  For multiple connections, it may become impossible to honor the preferred
-	  spacing, in which case overlapping will occur.
+	  The preferred connection spacing between multiple simultaneous central
+	  roles in microseconds. The Controller will calculate the required time
+	  reservation using the data length and PHY currently in use. The
+	  greater of the preferred spacing and the calculated time reservation
+	  will be used.
+	  The precision is determined by the resolution of the platform
+	  dependent ticker clock.
+	  The upper range is a ceil value permitting any tuning of Controller's
+	  radio handling overheads and to allow Coded PHY S8 coding scheme PDU
+	  time, i.e. radio event overheads + 17040 (PDU Tx) + 150 (tIFS) + 4
+	  (active clock jitter) + 17040 (PDU rx) = (radio event overheads +
+	  34234) microseconds.
+
+config BT_CTLR_CENTRAL_RESERVE_MAX
+	bool "Use maximum data PDU size time reservation for Central"
+	depends on BT_CENTRAL
+	default y
+	help
+	  Use the maximum data PDU size time reservation considering the Data
+	  length could be updated from default 27 bytes to maximum support size.
+	  If maximum time reservation is disabled then time reservation
+	  corresponding to the default data length at the time of the
+	  start/enable of Central role is used.
+
+	  Note, currently this value is only used to space multiple central
+	  connections and not for actual ticker time reservations.
+
+config BT_CTLR_SLOT_RESERVATION_UPDATE
+	bool "Update event length reservation after PHY or DLE update"
+	depends on !BT_LL_SW_LLCP_LEGACY && (BT_CTLR_DATA_LENGTH || BT_CTLR_PHY)
+	default y
+	help
+	  Updates the event length reservation after a completed Data Length Update
+	  and/or PHY Update procedure to avoid overlap of radio events
 
 config BT_CTLR_LLL_PRIO
 	int "Lower Link Layer (Radio) IRQ priority" if (BT_CTLR_ULL_LLL_PRIO_SUPPORT && !BT_CTLR_ZLI)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1106,10 +1106,11 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-		conn->llcp_conn_param.req = 0;
-		conn->llcp_conn_param.ack = 0;
-		conn->llcp_conn_param.disabled = 0;
-		conn->periph.ticks_to_offset = 0;
+		conn->llcp_conn_param.req = 0U;
+		conn->llcp_conn_param.ack = 0U;
+		conn->llcp_conn_param.disabled = 0U;
+		conn->llcp_conn_param.cache.timeout = 0U;
+		conn->periph.ticks_to_offset = 0U;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1078,6 +1078,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0;
 		conn->llcp_rx = NULL;
 		conn->llcp_cu.req = conn->llcp_cu.ack = 0;
+		conn->llcp_cu.pause_tx = 0U;
 		conn->llcp_feature.req = conn->llcp_feature.ack = 0;
 		conn->llcp_feature.features_conn = ll_feat_get();
 		conn->llcp_feature.features_peer = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -347,6 +347,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	conn->llcp_conn_param.req = 0U;
 	conn->llcp_conn_param.ack = 0U;
+	conn->llcp_conn_param.cache.timeout = 0U;
 	conn->llcp_conn_param.disabled = 0U;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -318,6 +318,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0U;
 	conn->llcp_rx = NULL;
 	conn->llcp_cu.req = conn->llcp_cu.ack = 0;
+	conn->llcp_cu.pause_tx = 0U;
 	conn->llcp_feature.req = conn->llcp_feature.ack = 0;
 	conn->llcp_feature.features_conn = ll_feat_get();
 	conn->llcp_feature.features_peer = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1154,6 +1154,17 @@ int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy)
 
 		/* check if connection update procedure is requested */
 		if (conn->llcp_cu.ack != conn->llcp_cu.req) {
+			/* Delay until all pending Tx in LLL is acknowledged,
+			 * new Tx PDUs will not be enqueued until we proceed to
+			 * initiate connection update and get acknowledged.
+			 * This is required to ensure PDU with instant can be
+			 * transmitted before instant expires.
+			 */
+			if (memq_peek(conn->lll.memq_tx.head,
+				      conn->lll.memq_tx.tail, NULL)) {
+				return 0;
+			}
+
 			/* switch to LLCP_CONN_UPD state machine */
 			conn->llcp_type = LLCP_CONN_UPD;
 			conn->llcp_ack -= 2U;
@@ -1910,6 +1921,7 @@ void ull_conn_tx_lll_enqueue(struct ll_conn *conn, uint8_t count)
 
 	while (conn->tx_head &&
 	       ((
+		 (conn->llcp_cu.req == conn->llcp_cu.ack) &&
 #if defined(CONFIG_BT_CTLR_PHY)
 		 !conn->llcp_phy.pause_tx &&
 #endif /* CONFIG_BT_CTLR_PHY */
@@ -2828,6 +2840,7 @@ static inline void ctrl_tx_pause_enqueue(struct ll_conn *conn,
 	if (
 	    /* data/ctrl packet is in the head */
 	    conn->tx_head &&
+	    !conn->llcp_cu.pause_tx &&
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	    !conn->llcp_enc.pause_tx &&
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -3177,8 +3190,15 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 					     llctrl.conn_update_ind.win_offset);
 			pdu_ctrl_tx->llctrl.conn_update_ind.instant =
 				sys_cpu_to_le16(conn->llcp.conn_upd.instant);
+
 			/* move to in progress */
 			conn->llcp_cu.state = LLCP_CUI_STATE_INPROG;
+
+			/* Data PDU tx paused, as we ensure PDUs in LLL have all
+			 * been ack-ed.
+			 */
+			conn->llcp_cu.pause_tx = 1U;
+
 			/* enqueue control PDU */
 			tx = CONTAINER_OF(pdu_ctrl_tx, struct node_tx, pdu);
 			ctrl_tx_enqueue(conn, tx);
@@ -3225,6 +3245,12 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 					      conn->lll.latency + 6;
 		pdu_ctrl_tx->llctrl.conn_update_ind.instant =
 			sys_cpu_to_le16(conn->llcp.conn_upd.instant);
+
+		/* Data PDU tx paused, as we ensure PDUs in LLL have all been
+		 * ack-ed.
+		 */
+		conn->llcp_cu.pause_tx = 1U;
+
 		/* enqueue control PDU */
 		ctrl_tx_enqueue(conn, tx);
 #endif /* !CONFIG_BT_CTLR_SCHED_ADVANCED */
@@ -6515,6 +6541,12 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		/* Reset the transaction lock */
 		conn->common.txn_lock = 0U;
 		break;
+
+#if defined(CONFIG_BT_CENTRAL)
+	case PDU_DATA_LLCTRL_TYPE_CONN_UPDATE_IND:
+		conn->llcp_cu.pause_tx = 0U;
+		break;
+#endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -243,12 +243,19 @@ struct ll_conn {
 			LLCP_CPR_STATE_OFFS_RDY,
 		} state:4 __packed;
 		uint8_t  cmd:1;
+		uint8_t  remote:1;
 		uint8_t  disabled:1;
 		uint8_t  status;
 		uint16_t interval_min;
 		uint16_t interval_max;
 		uint16_t latency;
 		uint16_t timeout;
+		struct {
+			uint16_t interval_min;
+			uint16_t interval_max;
+			uint16_t latency;
+			uint16_t timeout;
+		} cache;
 		uint8_t  preferred_periodicity;
 		uint16_t reference_conn_event_count;
 		uint16_t offset0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -169,6 +169,7 @@ struct ll_conn {
 			LLCP_CUI_STATE_REJECT,
 		} state:3 __packed;
 		uint8_t  cmd:1;
+		uint8_t  pause_tx:1;
 		uint16_t interval;
 		uint16_t latency;
 		uint16_t timeout;

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/bluetooth/hci.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -48,6 +47,7 @@
 #define LOG_MODULE_NAME bt_ctlr_ull_sched
 #include "common/log.h"
 #include "hal/debug.h"
+#include "ll_feat.h"
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
@@ -876,7 +876,47 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 
 		conn = ll_conn_get(ticker_id - TICKER_ID_CONN_BASE);
 		if (conn && !conn->lll.role) {
-			*ticks_slot = conn->ull.ticks_slot;
+			uint32_t ticks_slot_conn;
+
+			if (IS_ENABLED(CONFIG_BT_CTLR_CENTRAL_RESERVE_MAX)) {
+				uint32_t ready_delay_us;
+				uint16_t max_tx_time;
+				uint16_t max_rx_time;
+				uint32_t time_us;
+
+#if defined(CONFIG_BT_CTLR_PHY)
+				ready_delay_us =
+					lll_radio_tx_ready_delay_get(conn->lll.phy_tx,
+								     conn->lll.phy_flags);
+#else
+				ready_delay_us =
+					lll_radio_tx_ready_delay_get(0U, 0U);
+#endif
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
+				max_tx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX,
+							    PHY_CODED);
+				max_rx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX,
+							    PHY_CODED);
+#else /* !CONFIG_BT_CTLR_PHY_CODED */
+				max_tx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX,
+							    PHY_1M);
+				max_rx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX,
+							    PHY_1M);
+#endif /* !CONFIG_BT_CTLR_PHY_CODED */
+
+				time_us = EVENT_OVERHEAD_START_US +
+					  ready_delay_us +  max_rx_time +
+					  EVENT_IFS_US + max_tx_time;
+				ticks_slot_conn =
+					HAL_TICKER_US_TO_TICKS(time_us);
+			} else {
+				ticks_slot_conn = conn->ull.ticks_slot;
+			}
+
+			*ticks_slot = MAX(ticks_slot_conn,
+				    HAL_TICKER_US_TO_TICKS(
+					    CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING));
 
 			return &conn->ull;
 		}

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
@@ -43,3 +43,7 @@ CONFIG_BT_CTLR_RX_BUFFERS=6
 # accuracy, current value here is sufficient for 500ppm at 1 second interval.
 CONFIG_BT_CTLR_ADVANCED_FEATURES=y
 CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING=1000
+
+# Do not use max data PDU size time reservation for connection events spacing
+# instead use lesser value as supplied in CONFIG_BT_CTLR_CENTRAL_SPACING
+CONFIG_BT_CTLR_CENTRAL_RESERVE_MAX=n

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.set1.test_list
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.set1.test_list
@@ -35,7 +35,7 @@ LL/CON/CEN/BV-21-C
 LL/CON/CEN/BV-23-C
 LL/CON/CEN/BV-24-C
 LL/CON/CEN/BV-25-C
-LL/CON/CEN/BV-26-C
+#LL/CON/CEN/BV-26-C # This test case is not valid, and will fail with CPR cache
 LL/CON/CEN/BV-27-C
 LL/CON/CEN/BV-29-C
 LL/CON/CEN/BV-30-C


### PR DESCRIPTION
Fix legacy control procedure implementation to avoid connection update procedure with reason instant passed (0x28).

Connection Update Indication PDU is enqueued after data enqueue to LLL context is paused and the enqueue resumes when already enqueued data PDUs are all acknowledged.