### PR TITLE
boards: arm: sparkfun_pro_micro_rp2040: Fix D0/1

### DIFF
--- a/boards/arm/adafruit_kb2040/sparkfun_pro_micro.dtsi
+++ b/boards/arm/adafruit_kb2040/sparkfun_pro_micro.dtsi
@@ -11,8 +11,8 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map
-			= <0 0 &gpio0 0 0>		/* D0 */
-			, <1 0 &gpio0 1 0>		/* D1 */
+			= <1 0 &gpio0 0 0>		/* D1 */
+			, <0 0 &gpio0 1 0>		/* D0 */
 			, <2 0 &gpio0 2 0>		/* D2 */
 			, <3 0 &gpio0 3 0>		/* D3 */
 			, <4 0 &gpio0 4 0>		/* D4/A6 */

--- a/boards/arm/sparkfun_pro_mirco_rp2040/sparkfun_pro_micro.dtsi
+++ b/boards/arm/sparkfun_pro_mirco_rp2040/sparkfun_pro_micro.dtsi
@@ -11,8 +11,8 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map
-			= <0 0 &gpio0 0 0>		/* D0 */
-			, <1 0 &gpio0 1 0>		/* D1 */
+			= <1 0 &gpio0 0 0>		/* D1 */
+			, <0 0 &gpio0 1 0>		/* D0 */
 			, <2 0 &gpio0 2 0>		/* D2 */
 			, <3 0 &gpio0 3 0>		/* D3 */
 			, <4 0 &gpio0 4 0>		/* D4/A6 */


### PR DESCRIPTION
Fix the mapping of D0/D1 nexus node since the
pro micro format has the 1 pin at the top, 0
pin below that.