### PR TITLE
boards: arm: Fix sparkfun_pro_micro_rp2040 gpiomap

### DIFF
--- a/boards/arm/sparkfun_pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
+++ b/boards/arm/sparkfun_pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
@@ -11,8 +11,8 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map
-			= <0 0 &gpio0 0 0>		/* D0 */
-			, <1 0 &gpio0 1 0>		/* D1 */
+			= <1 0 &gpio0 0 0>		/* D1 */
+			, <0 0 &gpio0 1 0>		/* D0 */
 			, <2 0 &gpio0 2 0>		/* D2 */
 			, <3 0 &gpio0 3 0>		/* D3 */
 			, <4 0 &gpio0 4 0>		/* D4/A6 */


### PR DESCRIPTION
The SparkFun Pro Micro pins are numbered 1, 0, GND, ... from top left whereas the SparkFun Pro Micro RP2040 and the RP2040 Community Edition boards are numbered 0, 1, GND, ... , so the pro-micro connector gpio-map should reflect that.