### PR TITLE
drivers: adc: Fix overflow calculation bug in voltage divider.

### DIFF
--- a/include/zephyr/drivers/adc/voltage_divider.h
+++ b/include/zephyr/drivers/adc/voltage_divider.h
@@ -51,7 +51,7 @@ static inline int voltage_divider_scale_dt(const struct voltage_divider_dt_spec 
 	}
 
 	/* voltage scaled by voltage divider values using DT binding */
-	*v_to_v = *v_to_v * spec->full_ohms / spec->output_ohms;
+	*v_to_v = *v_to_v * (uint64_t)spec->full_ohms / spec->output_ohms;
 
 	return 0;
 }


### PR DESCRIPTION
The calculation to adjust a voltage divider value can overflow the 32-bit max when using a large `full_ohms` causing the calculation to be off. Cast up to 64-bits during the calculation to avoid this.