### PR TITLE
fix(boards): Suppress spurious devicetree warning

### DIFF
--- a/boards/arm/seeeduino_xiao_ble/pre_dt_board.cmake
+++ b/boards/arm/seeeduino_xiao_ble/pre_dt_board.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+#
+
+# Suppresses duplicate unit-address warning at build time for power, clock, acl and flash-controller
+# https://docs.zephyrproject.org/latest/build/dts/intro-input-output.html
+
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
Addresses https://github.com/zmkfirmware/zmk/pull/2318 for the seeeduino xiao BLE