### PR TITLE
hal_rpi_pico: set PICO_XOSC_STARTUP_DELAY_MULTIPLIER

### DIFF
--- a/modules/hal_rpi_pico/pico/config_autogen.h
+++ b/modules/hal_rpi_pico/pico/config_autogen.h
@@ -32,6 +32,8 @@
 /* Disable binary info */
 #define PICO_NO_BINARY_INFO 1
 
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+
 /* Zephyr compatible way of forcing inline */
 #ifndef __always_inline
 #define __always_inline ALWAYS_INLINE


### PR DESCRIPTION
On some boards, XOSC can take longer to stabilize. This is needed to prevent a hard fault on reset.

See zephyrproject-rtos/zephyr#78200