### PR TITLE
drivers: serial: Pico PIO UART wait for initial high

### DIFF
--- a/drivers/serial/uart_rpi_pico_pio.c
+++ b/drivers/serial/uart_rpi_pico_pio.c
@@ -39,15 +39,15 @@ RPI_PICO_PIO_DEFINE_PROGRAM(uart_tx, 0, 3,
 		/* .wrap */
 );
 
-RPI_PICO_PIO_DEFINE_PROGRAM(uart_rx, 0, 8,
+RPI_PICO_PIO_DEFINE_PROGRAM(uart_rx, 1, 8,
+	0x20a0, /*  0: wait   1 pin, 0                    */
 		/*  .wrap_target */
-	0x2020, /*  0: wait   0 pin, 0                    */
-	0xea27, /*  1: set    x, 7                   [10] */
-	0x4001, /*  2: in     pins, 1                     */
-	0x0642, /*  3: jmp    x--, 2                 [6]  */
-	0x00c8, /*  4: jmp    pin, 8                      */
-	0xc014, /*  5: irq    nowait 4 rel                */
-	0x20a0, /*  6: wait   1 pin, 0                    */
+	0x2020, /*  1: wait   0 pin, 0                    */
+	0xea27, /*  2: set    x, 7                   [10] */
+	0x4001, /*  3: in     pins, 1                     */
+	0x0643, /*  4: jmp    x--, 3                 [6]  */
+	0x00c8, /*  5: jmp    pin, 8                      */
+	0xc014, /*  6: irq    nowait 4 rel                */
 	0x0000, /*  7: jmp    0                           */
 	0x8020, /*  8: push   block                       */
 		/*  .wrap */


### PR DESCRIPTION
Adjust the PIO assemble for the UART RX to wait for the line to initially be high before starting the wrap loop and wait for a low start bit.

This comes from a report on Discord:

> I've been testing the latest a bit and it is solid for me also. 
> 
> The only issue I've faced is that my peripheral always receives a byte (0x00) on boot, which offsets the actual commands causing them to be corrupted.
> 
> I've copied what xudongz did with a prefix to test and now able to do bootloader and rgb across both sides. 
It only happens if the peripheral is connected to central while central is powered on, so not sure if it is my board definition, the pio driver, or a hardware issue, but is not related to the PR.