### PR TITLE
drivers: display: st7789v: Add ready time to startup

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -46,6 +46,7 @@ struct st7789v_config {
 	uint8_t rgb_param[3];
 	uint16_t height;
 	uint16_t width;
+	uint8_t ready_time_ms;
 };
 
 struct st7789v_data {
@@ -376,6 +377,8 @@ static int st7789v_init(const struct device *dev)
 		}
 	}
 
+	k_sleep(K_TIMEOUT_ABS_MS(config->ready_time_ms));
+
 	st7789v_reset_display(dev);
 
 	st7789v_blanking_on(dev);
@@ -450,6 +453,7 @@ static const struct display_driver_api st7789v_api = {
 		.rgb_param = DT_INST_PROP(inst, rgb_param),				\
 		.width = DT_INST_PROP(inst, width),					\
 		.height = DT_INST_PROP(inst, height),					\
+		.ready_time_ms = DT_INST_PROP(inst, ready_time_ms),			\
 	};										\
 											\
 	static struct st7789v_data st7789v_data_ ## inst = {				\

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -111,3 +111,11 @@ properties:
     type: uint8-array
     required: true
     description: RGB Interface Control Parameter
+
+  ready-time-ms:
+    type: int
+    default: 40
+    description: |
+      Time it takes for the device from power up to become responsive and
+      accepting commands. Defaults to 40ms (found by trial and error) if not
+      provided.


### PR DESCRIPTION
Add additional property to allow a configurable delay to the display initialization to allow the st7789v to be ready to receive commands.