### PR TITLE
fix: changed shebang to make scripts more platform independent

### DIFF
--- a/scripts/net/run-sample-tests.sh
+++ b/scripts/net/run-sample-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_2.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_2.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
See for example [this thread](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash) on why its better to use '#!/usr/bin/env bash' instead. Without this change these scripts will not run on some platforms. This is not a breaking change for the platforms it already works on.