### PR TITLE
fix: revert https://github.com/zephyrproject-rtos/zephyr/pull/69682

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -272,7 +272,6 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
  */
 #define Z_PM_DEVICE_NAME(dev_id) _CONCAT(__pm_device_, dev_id)
 
-#ifdef CONFIG_PM
 /**
  * @brief Define device PM slot.
  *
@@ -287,9 +286,6 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
 #define Z_PM_DEVICE_DEFINE_SLOT(dev_id)					\
 	static STRUCT_SECTION_ITERABLE_ALTERNATE(pm_device_slots, device, \
 			_CONCAT(__pm_slot_, dev_id))
-#else
-#define Z_PM_DEVICE_DEFINE_SLOT(dev_id)
-#endif /* CONFIG_PM */
 
 #ifdef CONFIG_PM_DEVICE
 /**


### PR DESCRIPTION
This PR fixes the following issues in ZMK: https://github.com/zmkfirmware/zmk/issues/3207 and https://github.com/zmkfirmware/zmk/issues/3195

`pm_device_slots` is missing for `pm.c` in ZMK. Which causes the whole keyboard to lock up and be unresponsive if pm_device_action_run returns with `0`. 

See my comment here for further explanation: https://github.com/zmkfirmware/zmk/issues/3207#issuecomment-4779908164