### PR TITLE
Bluetooth: Controller: fix split central crash and conn param update assert

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -174,7 +174,7 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 	 * exchanged.
 	 */
 	if ((next == curr) && (trx_cnt < 1U)) {
-		return -EBUSY;
+		return -ECANCELED;
 	}
 
 	return -ECANCELED;
@@ -196,7 +196,7 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 	 * been exchanged.
 	 */
 	if ((next == curr) && (tx_cnt < 1U)) {
-		return -EBUSY;
+		return -ECANCELED;
 	}
 
 	return -ECANCELED;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2338,7 +2338,7 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 	periodic_us = conn_interval_us;
 
 	conn_interval_old_us = conn_interval_old * conn_interval_unit_old;
-	latency_upd = conn_interval_old_us / conn_interval_us;
+	latency_upd = DIV_ROUND_UP(conn_interval_old_us, conn_interval_us);
 	conn_interval_new_us = latency_upd * conn_interval_us;
 	if (conn_interval_new_us > conn_interval_old_us) {
 		ticks_at_expire += HAL_TICKER_US_TO_TICKS(


### PR DESCRIPTION
Fixes the split central crash zmkfirmware/zmk#3370 was opened to diagnose (and thanks to the core dumps that made fixing this possible). Additionally cherry-picks upstream commit that fixes zmkfirmware/zmk#3331 since I ran into that crash also when trying to reproduce the former and the fix was tested with both commits.

Supersedes #51, same cherry-pick.

The bug has been possibly resolved upstream by a [prepare deferred feature](https://github.com/zephyrproject-rtos/zephyr/commit/c2eb901ea1d4ae00209c07166097073faac8108a), so the solution here has no upstream value, and should be replaced by the prepare deferred feature when ZMK upgrades to Zephyr 4.4.